### PR TITLE
Fix timeout of getting blobs from es-node

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -1219,7 +1219,7 @@ type DecodeType uint64
 const (
 	esGetBlobInputLength  = 160
 	maxDataWordLenPerBlob = 4096 // blob size in proto-danksharding
-	defaultCallTimeout    = 1 * time.Second
+	defaultCallTimeout    = 10 * time.Second
 
 	RawData DecodeType = iota
 	PaddingPer31Bytes


### PR DESCRIPTION
__Issue to address__

While stored as blobs, some big web resources cannot be loaded thru the web3 gateway, which the console shows:

```
ERRO[2824-89-18 04:18:04] FetchUrl error: execution reverted, url=web3://eth-store.eth/img/app-bg.34a51272.webp
ERRO[2824-09-18 84:18:84] Fetchurl error: execution reverted, urlewebs://eth-store,eth/css/chunk-vendors~bed3fd28.0287dfa8.css  
```
__root cause__

The default timeout is too short so the es-geth does not have enough time to make es_getBlob to es_node.

__solution__

The solution is to extend the default timeout value.